### PR TITLE
Realtime Pixel Sync and Database Update Change

### DIFF
--- a/src/lib/comp/canvas/objects/PixelGrid.ts
+++ b/src/lib/comp/canvas/objects/PixelGrid.ts
@@ -111,6 +111,7 @@ export class PixelGrid extends CanvasObject {
 					lastedEditedUserID: this.userID,
 					lastedEditedName: this.userDisplayName
 				});
+				this.realtimeManager.broadcastChanges(); // push any pending pixel changes to the server
 			}
 		}
 	}
@@ -271,7 +272,7 @@ export class PixelGrid extends CanvasObject {
 			this.placePixel(sctx.cursor.relx, sctx.cursor.rely, sctx.pixelGrid.brush.color, sctx);
 		}
 
-		this.realtimeManager.broadcastThenSave(this.pixels); // push any pending pixel changes to the server
+		this.realtimeManager.saveToDatabase(this.pixels); // push pixel changes (will not send anything if there are no new pixels to be sent)
 		sctx.pixelGrid.brush.active = false;
 	}
 }


### PR DESCRIPTION
**Changes:**

- Broadcast and Saving to the database have now been decoupled (broadcasting is its own function now)
- Broadcasting pixel changes to other users is now done for every pixel change
- Database saving is now done when the cursor is lifted, provided that there are actually pixels to send
